### PR TITLE
Fix indentation of ActiveJobs callbacks example

### DIFF
--- a/guides/source/active_job_basics.md
+++ b/guides/source/active_job_basics.md
@@ -325,11 +325,12 @@ class GuestsCleanupJob < ApplicationJob
   end
 
   private
-    def around_cleanup
-      # Do something before perform
-      yield
-      # Do something after perform
-    end
+  
+  def around_cleanup
+    # Do something before perform
+    yield
+    # Do something after perform
+  end
 end
 ```
 


### PR DESCRIPTION
The formatting of the example code for `ActiveJob` callbacks was  incorrect.

This updates the formatting of the `around_cleanup` example  method to make it consistent with the rest of the examples  in the `ActiveJob` guide.